### PR TITLE
Workflow de up/down en Railway y fix de la config de Sass perdida en el merge del #11

### DIFF
--- a/.github/workflows/railway-updown.yml
+++ b/.github/workflows/railway-updown.yml
@@ -1,0 +1,126 @@
+# Levanta o baja el servicio de la API en Railway a demanda.
+#
+# Se corre a mano: pestaña Actions -> "Railway: levantar / bajar la API" -> Run workflow,
+# y elegís la acción en el desplegable.
+#
+# Requiere en el repo (Settings -> Secrets and variables -> Actions):
+#   secret  RAILWAY_TOKEN   -> Project Token de Railway (Settings del proyecto -> Tokens).
+#                              Tiene que ser un PROJECT token, no uno de cuenta: los de
+#                              cuenta van en RAILWAY_API_TOKEN y no sirven para deployar.
+#   var     RAILWAY_SERVICE -> nombre del servicio de la API en Railway.
+#   var     API_HEALTH_URL  -> https://<tu-api>.up.railway.app/health (para verificar el "up").
+#
+# OJO: esto sube y baja SOLO la API. El Postgres de Railway no se puede pausar por API,
+# así que su almacenamiento sigue consumiendo crédito aunque la API esté abajo.
+# Ver docs/deploy.md.
+
+name: "Railway: levantar / bajar la API"
+
+on:
+  workflow_dispatch:
+    inputs:
+      accion:
+        description: "Qué hacer con el servicio de la API"
+        required: true
+        type: choice
+        default: status
+        options:
+          - up
+          - down
+          - status
+
+# Que no se pisen dos corridas: bajar y levantar a la vez deja el servicio en un estado raro.
+concurrency:
+  group: railway-updown
+  cancel-in-progress: false
+
+jobs:
+  updown:
+    name: "${{ inputs.accion }}"
+    runs-on: ubuntu-latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_SERVICE: ${{ vars.RAILWAY_SERVICE }}
+      API_HEALTH_URL: ${{ vars.API_HEALTH_URL }}
+
+    steps:
+      - name: Validar configuración
+        run: |
+          faltan=0
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "Falta el secret RAILWAY_TOKEN"
+            faltan=1
+          fi
+          if [ -z "$RAILWAY_SERVICE" ]; then
+            echo "Falta la variable RAILWAY_SERVICE"
+            faltan=1
+          fi
+          if [ "$faltan" -eq 1 ]; then
+            echo "::error::Configuralo en Settings -> Secrets and variables -> Actions. Ver docs/deploy.md."
+            exit 1
+          fi
+          echo "Servicio: $RAILWAY_SERVICE"
+
+      - uses: actions/checkout@v4
+        if: inputs.accion == 'up'
+
+      - name: Instalar Railway CLI
+        run: npm install -g @railway/cli
+
+      # `railway up` sube el contenido del directorio y construye con el Dockerfile
+      # que encuentra ahí, por eso corre desde el directorio de la solución.
+      - name: Levantar la API
+        if: inputs.accion == 'up'
+        working-directory: api/HealthArchiveAPI
+        run: railway up --ci --service "$RAILWAY_SERVICE"
+
+      # Espera a que el healthcheck responda: sin esto el workflow termina en verde
+      # apenas Railway acepta el deploy, aunque la app todavía no esté sirviendo.
+      - name: Esperar a que responda /health
+        if: inputs.accion == 'up'
+        run: |
+          if [ -z "$API_HEALTH_URL" ]; then
+            echo "::warning::Sin API_HEALTH_URL no puedo verificar que haya levantado."
+            exit 0
+          fi
+          for i in $(seq 1 30); do
+            codigo=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$API_HEALTH_URL" || echo 000)
+            if [ "$codigo" = "200" ]; then
+              echo "API arriba (intento $i)."
+              exit 0
+            fi
+            echo "Intento $i: HTTP $codigo, reintento en 10s..."
+            sleep 10
+          done
+          echo "::error::La API no respondió 200 en /health después de 5 minutos."
+          exit 1
+
+      # `railway down` elimina el último deployment del servicio; el servicio y su
+      # dominio quedan, así que al volver a levantarlo mantenés la misma URL (y no
+      # hay que tocar Cors__AllowedOrigins ni VITE_API_URL).
+      - name: Bajar la API
+        if: inputs.accion == 'down'
+        run: railway down --service "$RAILWAY_SERVICE" --yes
+
+      - name: Estado
+        if: inputs.accion == 'status'
+        run: |
+          railway status || true
+          if [ -n "$API_HEALTH_URL" ]; then
+            codigo=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$API_HEALTH_URL" || echo 000)
+            echo "GET $API_HEALTH_URL -> HTTP $codigo"
+          fi
+
+      - name: Resumen
+        if: always()
+        run: |
+          {
+            echo "### Railway — acción: \`${{ inputs.accion }}\`"
+            echo ""
+            echo "- Servicio: \`$RAILWAY_SERVICE\`"
+            echo "- Resultado del job: \`${{ job.status }}\`"
+            if [ "${{ inputs.accion }}" = "down" ]; then
+              echo ""
+              echo "> El Postgres sigue arriba: Railway no permite pausarlo por API."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -15,6 +15,21 @@ que estar en HTTPS** o el browser descarta la cookie.
 [ Railway ] postgres.railway.internal:5432    (Postgres administrado)
 ```
 
+> ### Costo: Railway no tiene free tier sostenido
+>
+> Vercel Hobby sí es gratis. Railway **no**: da un **trial de $5 por única vez**
+> (30 días, sin tarjeta), y después pasás a un plan Free con ~$1 de crédito mensual,
+> que no alcanza para tener la API prendida. Hobby son $5/mes y es *mínimo de gasto*,
+> no crédito: si consumís menos, pagás $5 igual.
+>
+> Por eso existe el workflow de la sección 6: para bajar la API cuando no la estás
+> usando y estirar el crédito del trial. **El Postgres no se puede pausar**, así que
+> su almacenamiento sigue consumiendo aunque la API esté abajo.
+>
+> Si en algún momento querés $0 sostenido, la alternativa es Render (free, con
+> spin-down a los 15 min y cold start de 30-60s) + Neon (free, scale-to-zero) para
+> Postgres. El Dockerfile sirve igual; solo cambia dónde se cargan las env vars.
+
 ---
 
 ## 0. Cómo se separan los ambientes
@@ -154,3 +169,43 @@ cada push: o los agregás, o simplemente no van a poder llamar al API).
 | 502 / healthcheck falla en Railway | La app no bindeó a `$PORT`, o crasheó al arrancar (mirar logs: `Jwt__Key` < 32 bytes) |
 | 404 al recargar una ruta del front | Falta el rewrite de `vercel.json` o el Root Directory no es `web-app` |
 | `relation "Doctors" does not exist` | Nunca corrieron las migraciones → `RunMigrationsOnStartup=true` y redeploy |
+
+---
+
+## 6. Levantar y bajar la API desde GitHub Actions
+
+Workflow: [`.github/workflows/railway-updown.yml`](../.github/workflows/railway-updown.yml).
+Se corre a mano desde **Actions → "Railway: levantar / bajar la API" → Run workflow**,
+eligiendo la acción en el desplegable.
+
+| Acción | Qué hace |
+|---|---|
+| `up` | `railway up --ci` desde `api/HealthArchiveAPI` (build + deploy) y después espera a que `/health` devuelva 200, hasta 5 minutos |
+| `down` | `railway down --yes`, que elimina el último deployment del servicio |
+| `status` | `railway status` + un GET a `/health`, sin tocar nada |
+
+### Configuración previa (una sola vez)
+
+1. En Railway: **Settings del proyecto → Tokens → New Token**, scope al environment
+   `production`. Es un **Project Token**; los tokens de cuenta no sirven para deployar
+   (esos van en `RAILWAY_API_TOKEN`, que este workflow no usa).
+2. En GitHub: **Settings → Secrets and variables → Actions**
+   - Secret `RAILWAY_TOKEN` = el token del paso 1.
+   - Variable `RAILWAY_SERVICE` = el nombre del servicio de la API en Railway.
+   - Variable `API_HEALTH_URL` = `https://<tu-api>.up.railway.app/health`.
+
+Si falta algo, el primer step corta con un mensaje que dice exactamente qué.
+
+### Qué esperar
+
+- **La URL no cambia.** `railway down` borra el deployment, no el servicio, así que el
+  dominio queda asignado y al volver a levantar sirve la misma URL. No hay que tocar
+  `Cors__AllowedOrigins` ni `VITE_API_URL` entre un ciclo y otro.
+- **El front sigue arriba.** Vercel Hobby es gratis, no hay razón de costo para bajarlo.
+  Con la API abajo, el SPA carga pero cualquier llamada falla — es lo esperado.
+- **El Postgres sigue arriba.** Railway no expone forma de pausarlo por API (la API
+  pública no tiene mutación de stop/pause, y el CLI tampoco). Su almacenamiento sigue
+  consumiendo crédito. Si querés cortar del todo, hay que borrar el servicio a mano
+  desde el dashboard, y eso **borra los datos**.
+- El `up` reconstruye la imagen en Railway, así que tarda lo que tarde el build de
+  Docker — no son segundos.

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -25,5 +25,17 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 3000,
     },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          // Bootstrap 5.3 compilado desde source emite deprecations de dart-sass
+          // (@import, funciones de color legacy). Son cosméticas; sin esto el
+          // build es ilegible.
+          api: 'modern-compiler',
+          quietDeps: true,
+          silenceDeprecations: ['import'],
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
Dos cosas: el pipeline para levantar y bajar la API a demanda, y la reposición de un bloque de config que se perdió resolviendo el conflicto del PR anterior.

## 1. Workflow de up/down en Railway

**Por qué.** Railway no tiene free tier sostenido: da un **trial de $5 por única vez** y después pasa a ~$1 de crédito mensual, que no alcanza para tener la API prendida. Hobby son $5/mes y es *mínimo de gasto*, no crédito. Para estirar el trial mientras probamos, hace falta poder apagar la API cuando no se usa.

`.github/workflows/railway-updown.yml` — `workflow_dispatch` con un desplegable:

| Acción | Qué hace |
|---|---|
| `up` | `railway up --ci` desde `api/HealthArchiveAPI`, y después **espera a que `/health` devuelva 200** (hasta 5 min) |
| `down` | `railway down --yes` |
| `status` | `railway status` + GET a `/health`, sin tocar nada |

El paso de espera existe porque sin él el workflow termina en verde apenas Railway acepta el deploy, aunque la app todavía no esté sirviendo.

**Configuración previa** (documentada en `docs/deploy.md` §6): secret `RAILWAY_TOKEN` con un **Project Token** (los tokens de cuenta no sirven para deployar, esos van en `RAILWAY_API_TOKEN`), más las variables `RAILWAY_SERVICE` y `API_HEALTH_URL`. Si falta algo, el primer step corta con un mensaje que dice exactamente qué.

**Límites, verificados contra la documentación:**

- **La URL no cambia** entre ciclos. `railway down` elimina el deployment, no el servicio, así que el dominio queda asignado y no hay que retocar `Cors__AllowedOrigins` ni `VITE_API_URL`.
- **El Postgres no se puede bajar.** La API pública de Railway no expone ninguna mutación de stop/pause y el CLI tampoco; lo único cercano es `serviceInstanceUpdate` con `numReplicas`, que según la propia doc escribe configuración pero no reconcilia el estado de runtime. Su almacenamiento sigue consumiendo crédito. Bajarlo de verdad implica borrar el servicio a mano, y eso borra los datos.
- **El front se deja arriba.** Vercel Hobby es gratis, no hay razón de costo para bajarlo.

También agregué al principio de `docs/deploy.md` un bloque que aclara la situación del free tier y deja anotada la alternativa de $0 sostenido (Render free + Neon free) por si más adelante hace falta — el Dockerfile sirve igual ahí, solo cambia dónde se cargan las env vars.

## 2. Fix: se había perdido la config de Sass en el merge del #11

Al resolver el conflicto de `web-app/vite.config.ts` se tomó una sola punta y desapareció el bloque `css.preprocessorOptions` que había agregado el **#10 (RefactorUi)** para silenciar las deprecations de dart-sass de Bootstrap 5.3. Lo repongo junto al guard de `VITE_API_URL`, que es lo que había entrado por la otra punta; ahora conviven los dos. Con esto el build del front vuelve a salir limpio.

## Para el reviewer

- **El workflow no está probado contra Railway.** Lo escribí contra la documentación oficial del CLI (`up --ci --service`, `down --yes`, project token en `RAILWAY_TOKEN`), pero no tengo acceso a la cuenta, así que la primera corrida es la prueba real. Es esperable tener que ajustar algún flag con el log a la vista.
- **Bug encontrado y corregido durante el armado:** GitHub corre los `run` con `bash -e`, así que el patrón `[ -z "$VAR" ] && faltan=...` devuelve 1 cuando la variable *sí* está — el step de validación habría fallado justo con la configuración correcta. Reescrito con `if` y testeado en ambos casos.
- El workflow no toca `master` ni deploya solo: es 100% manual (`workflow_dispatch`), no hay trigger en push.
- Verifiqué que en `master` siguen el `Dockerfile`, `vercel.json`, `appsettings.Production.json` y `docs/deploy.md`, que AutoMapper y `Microsoft.EntityFrameworkCore.Tools` siguen afuera, y que la solución no tiene paquetes vulnerables. Backend y front compilan en 0 errores.
- Quedó fuera del commit un `.claude/skills/prompt-master/` sin trackear que apareció en el working tree y no tiene que ver con este trabajo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
