### PR TITLE
Fix: railway up debe correr desde la raiz del repo, no desde api/

### DIFF
--- a/.github/workflows/railway-updown.yml
+++ b/.github/workflows/railway-updown.yml
@@ -67,11 +67,14 @@ jobs:
       - name: Instalar Railway CLI
         run: npm install -g @railway/cli
 
-      # `railway up` sube el contenido del directorio y construye con el Dockerfile
-      # que encuentra ahí, por eso corre desde el directorio de la solución.
+      # Corre desde la RAÍZ del repo a propósito: `railway up` sube el contenido del
+      # directorio donde se ejecuta, y las settings del servicio (Root Directory y
+      # Dockerfile Path) están expresadas relativas a la raíz. Si se corriera desde
+      # api/HealthArchiveAPI, el snapshot arrancaría en esa carpeta y Railway fallaría
+      # con "failed to read Dockerfile at 'api/HealthArchiveAPI/Dockerfile'".
+      # Subir el repo entero replica exactamente lo que manda la integración de GitHub.
       - name: Levantar la API
         if: inputs.accion == 'up'
-        working-directory: api/HealthArchiveAPI
         run: railway up --ci --service "$RAILWAY_SERVICE"
 
       # Espera a que el healthcheck responda: sin esto el workflow termina en verde

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -202,7 +202,7 @@ eligiendo la acción en el desplegable.
 
 | Acción | Qué hace |
 |---|---|
-| `up` | `railway up --ci` desde `api/HealthArchiveAPI` (build + deploy) y después espera a que `/health` devuelva 200, hasta 5 minutos |
+| `up` | `railway up --ci` desde la **raíz del repo** (build + deploy) y después espera a que `/health` devuelva 200, hasta 5 minutos |
 | `down` | `railway down --yes`, que elimina el último deployment del servicio |
 | `status` | `railway status` + un GET a `/health`, sin tocar nada |
 
@@ -231,3 +231,9 @@ Si falta algo, el primer step corta con un mensaje que dice exactamente qué.
   desde el dashboard, y eso **borra los datos**.
 - El `up` reconstruye la imagen en Railway, así que tarda lo que tarde el build de
   Docker — no son segundos.
+- **El workflow sube el repo completo, no solo `api/`.** Es a propósito: las settings del
+  servicio (Root Directory `api/HealthArchiveAPI` y Dockerfile Path) están expresadas
+  relativas a la raíz, así que el snapshot tiene que arrancar ahí para que resuelvan. Es
+  exactamente lo que manda la integración de GitHub. Si se corriera `railway up` desde
+  `api/HealthArchiveAPI`, el build falla con
+  `failed to read Dockerfile at 'api/HealthArchiveAPI/Dockerfile'`.


### PR DESCRIPTION
El workflow corria `railway up` con working-directory en api/HealthArchiveAPI, asi que el snapshot subido arrancaba en esa carpeta (190 KB). Pero las settings del servicio en Railway (Root Directory y Dockerfile Path) estan expresadas relativas a la raiz del repo, asi que Railway buscaba api/HealthArchiveAPI/Dockerfile DENTRO de un snapshot que ya era esa carpeta, y el build fallaba con:

  failed to read Dockerfile at 'api/HealthArchiveAPI/Dockerfile'

Corriendo desde la raiz, el snapshot es el repo completo (1.4 MB) y queda identico al que manda la integracion de GitHub, que es el build que ya venia funcionando.